### PR TITLE
Fixes unused variable in requireConfig

### DIFF
--- a/web/gatsby-config.js
+++ b/web/gatsby-config.js
@@ -31,7 +31,7 @@ module.exports = {
 
 function requireConfig (path) {
   try {
-    return require('../studio/sanity.json')
+    return require(path)
   } catch (e) {
     console.error('Failed to require sanity.json. Fill in projectId and dataset name manually in gatsby-config.js')
     return {


### PR DESCRIPTION
When implementing a gatsby + sanity studio monorepo, I noticed this path variable was unused.